### PR TITLE
use Gradle for GitHub Actions workflows

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -32,3 +32,10 @@ jobs:
         path: |
           build/dist/*.zip
           build/out/*.pdf
+    - name: Publish Test Report
+      uses: dorny/test-reporter@v2
+      if: always()
+      with:
+        name: XSpec Tests
+        path: build/xspec/*-junit.xml
+        reporter: java-junit

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -21,8 +21,9 @@ jobs:
       uses: gradle/actions/setup-gradle@v4
       with:
         gradle-version: '8.14'
+        add-job-summary: never
     - name: Build with Gradle 8.14
-      run: ./gradlew runBuild
+      run: gradle runBuild
     - name: Upload Artifact
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -17,13 +17,11 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: '17'
-    - name: Setup Gradle
+    - name: Setup Gradle 8.14
       uses: gradle/actions/setup-gradle@v4
       with:
-        build-scan-publish: true
-        build-scan-terms-of-use-url: 'https://gradle.com/terms-of-service'
-        build-scan-terms-of-use-agree: 'yes'
-    - name: Build with Gradle
+        gradle-version: '8.14'
+    - name: Build with Gradle 8.14
       run: ./gradlew runBuild
     - name: Upload Artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -17,9 +17,14 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: '17'
-        cache: 'gradle'
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4
+      with:
+        build-scan-publish: true
+        build-scan-terms-of-use-url: 'https://gradle.com/terms-of-service'
+        build-scan-terms-of-use-agree: 'yes'
     - name: Build with Gradle
-      run: ./gradlew runBuild --no-daemon
+      run: ./gradlew runBuild
     - name: Upload Artifact
       uses: actions/upload-artifact@v4
       with:
@@ -27,10 +32,3 @@ jobs:
         path: |
           build/dist/*.zip
           build/out/*.pdf
-    - name: Publish Test Report
-      uses: dorny/test-reporter@v2
-      if: always()
-      with:
-        name: XSpec Tests
-        path: build/xspec/*-junit.xml
-        reporter: java-junit


### PR DESCRIPTION
Gradle for GitHub Actions workflows promises to simplify Gradle runs by caching and automating certain steps including test result detection. I'm intrigued. 